### PR TITLE
Better stringToAny, allows strings now

### DIFF
--- a/Text.lua
+++ b/Text.lua
@@ -4,7 +4,7 @@ Text.__index = Text
 require(text_path .. 'utf8-l')
 
 local tableContains = function(t, value) for k, v in pairs(t) do if v == value then return true end end end
-local stringToAny = function(str) return loadstring("return " .. str)() end
+local stringToAny = function(str) return ((loadstring("return " .. str) or function() end)() or str)  end
 
 function Text.new(x, y, text, settings)
     local self = {}


### PR DESCRIPTION
local stringToAny = function(str) return loadstring("return " .. str)()  end

print(stringToAny("test"))
--print(stringToAny("test string")) breakes the code
print(stringToAny("123") + 2)
print(stringToAny("123.2") + 3)

local stringToAny = function(str) return ((loadstring("return " .. str) or function() end)() or str)  end

print(stringToAny("test"))
print(stringToAny("test string"))
print(stringToAny("123") + 2)
print(stringToAny("123.2") + 3)

>nil
>125
>126.2
>test
>test string
>125
>126.2